### PR TITLE
Fix for CI on the newer .NET versions

### DIFF
--- a/LibreMetaverse.GUI/LibreMetaverse.GUI.csproj
+++ b/LibreMetaverse.GUI/LibreMetaverse.GUI.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' ">
-	<TargetFrameworks>net471;net48;netcoreapp3.1;net5.0;net6.0;net5.0-windows;net6.0-windows</TargetFrameworks>
+	<TargetFrameworks>net471;net48;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
-	<TargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-linux;net6.0-linux</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-	<TargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-linux;net6.0-linux</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>LibreMetaverse.GUI</AssemblyName>

--- a/Programs/Baker/Baker.csproj
+++ b/Programs/Baker/Baker.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' ">
-	<TargetFrameworks>net471;net48;netcoreapp3.1;net5.0;net6.0;net5.0-windows;net6.0-windows</TargetFrameworks>
+	<TargetFrameworks>net471;net48;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
-	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-linux;net6.0-linux</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-osx;net6.0-osx</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
 	<PackageId>Baker</PackageId>

--- a/Programs/examples/GridAccountant/GridAccountant.csproj
+++ b/Programs/examples/GridAccountant/GridAccountant.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' ">
-	<TargetFrameworks>net471;net48;netcoreapp3.1;net5.0;net6.0;net5.0-windows;net6.0-windows</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
-	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-linux;net6.0-linux</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net471;netcoreapp3.1;net5.0-osx;net6.0-osx</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
 	<PackageId>GridAccountant</PackageId>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.202",
-    "rollForward": "latestMajor"
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
[Appveyor only supports .NET SDK 6.0.201 as of now ](https://www.appveyor.com/updates/)while `global.json` is requesting `6.0.202` or later. I also think setting `"rollForward": "latestMinor"` is the safest option to keep it LTS compliant.

I updated the Target Frameworks for the GUI projects to get rid of some platform specific errors with the `net5.0` and `net6.0` targets.